### PR TITLE
Adiciona logs de inicialização no setup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,14 @@ void setup() {
     server.send(200, "text/html", html);
   });
   server.begin();
+  Serial.println("=== Configuração Iniciada ===");
+  Serial.printf("Sessões: %d\n", NUM_SESSIONS);
+  Serial.print("Duração irrigação: "); Serial.print(IRRIGATION_DURATION / 60000); Serial.println(" min");
+  Serial.print("Cooldown irrigação: "); Serial.print(IRRIGATION_COOLDOWN / 3600000); Serial.println(" h");
+  Serial.print("Luz: inicia às "); Serial.print(LIGHT_START_HOUR); Serial.print(" h por "); Serial.print(LIGHT_DURATION_HOURS); Serial.println(" h");
+  Serial.println("Servidor HTTP iniciado.");
+  Serial.print("Acesse em: http://"); Serial.print(WiFi.localIP()); Serial.println("/");
+  Serial.println("===========================");
 }
 
 void loop() {


### PR DESCRIPTION
Este PR adiciona mensagens via Serial no início da função setup() para facilitar o diagnóstico e informar:

- Número de sessões configuradas
- Duração do ciclo de irrigação
- Intervalo de cooldown
- Horário e duração da luz artificial
- URL de acesso ao servidor HTTP
