### PR TITLE
chore: add board support for ESP32 DOIT DevKit V1 (ESP32-D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Este projeto implementa um sistema de monitoramento e irrigação automática de
 
 ## Requisitos de Hardware
 
-- Placa ESP32 DEV.
+- Placa ESP32 DOIT DevKit V1 (ESP32-D).
 - 5 sensores de umidade de solo conectados aos pinos GPIO 37, 38, 39, 32 e 33.
 - 5 módulos de relé para as sessões de irrigação (GPIO 14–18).
 - Módulo de relé para a bomba de água (GPIO 12).

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
-[env:esp32dev]
+[env:esp32doit-devkit-v1]
 platform = espressif32
-board    = esp32dev
+board = esp32doit-devkit-v1
 framework= arduino
 monitor_speed = 115200


### PR DESCRIPTION
This PR updates the project configuration to support the ESP32 DOIT DevKit V1 (ESP32-D) board.

- `platformio.ini`: Changed environment name and board to `esp32doit-devkit-v1`.
- `README.md`: Updated hardware reference to ESP32 DOIT DevKit V1.

These updates ensure the correct board definitions are used for compilation and deployment.